### PR TITLE
feat: add layout presets utility with common page structure schemas

### DIFF
--- a/tests/layout-presets.test.js
+++ b/tests/layout-presets.test.js
@@ -1,0 +1,520 @@
+/**
+ * @fileoverview Tests for the layout presets utility.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TOKENS } from '../utils/design-tokens.js'
+import { resolveLayout } from '../utils/layout-engine.js'
+import {
+  createGamePageLayout,
+  createPageWithFooterButton,
+  createStandardPageLayout,
+  createTwoColumnLayout,
+  mergeLayouts
+} from '../utils/layout-presets.js'
+
+// Mock metrics for consistent testing
+const mockMetrics = {
+  width: 400,
+  height: 500,
+  isRound: false
+}
+
+const mockRoundMetrics = {
+  width: 466,
+  height: 466,
+  isRound: true
+}
+
+// ============================================
+// Test 1: createStandardPageLayout
+// ============================================
+test('createStandardPageLayout returns valid schema structure', () => {
+  const schema = createStandardPageLayout()
+
+  assert.ok(schema.sections)
+  assert.ok(schema.elements)
+  assert.ok(schema.sections.header)
+  assert.ok(schema.sections.body)
+  assert.ok(schema.sections.footer)
+})
+
+test('createStandardPageLayout includes all three sections by default', () => {
+  const schema = createStandardPageLayout()
+
+  assert.equal(typeof schema.sections.header, 'object')
+  assert.equal(typeof schema.sections.body, 'object')
+  assert.equal(typeof schema.sections.footer, 'object')
+})
+
+test('createStandardPageLayout with hasHeader: false excludes header', () => {
+  const schema = createStandardPageLayout({ hasHeader: false })
+
+  assert.equal(schema.sections.header, undefined)
+  assert.ok(schema.sections.body)
+  assert.ok(schema.sections.footer)
+})
+
+test('createStandardPageLayout with hasFooter: false excludes footer', () => {
+  const schema = createStandardPageLayout({ hasFooter: false })
+
+  assert.ok(schema.sections.header)
+  assert.ok(schema.sections.body)
+  assert.equal(schema.sections.footer, undefined)
+})
+
+test('createStandardPageLayout with hasHeader: false and hasFooter: false only has body', () => {
+  const schema = createStandardPageLayout({
+    hasHeader: false,
+    hasFooter: false
+  })
+
+  assert.equal(schema.sections.header, undefined)
+  assert.ok(schema.sections.body)
+  assert.equal(schema.sections.footer, undefined)
+})
+
+test('createStandardPageLayout sets roundSafeInset: true for body', () => {
+  const schema = createStandardPageLayout()
+
+  assert.equal(schema.sections.body.roundSafeInset, true)
+})
+
+test('createStandardPageLayout sets roundSafeInset: true for header', () => {
+  const schema = createStandardPageLayout()
+
+  assert.equal(schema.sections.header.roundSafeInset, true)
+})
+
+test('createStandardPageLayout sets roundSafeInset: false for footer', () => {
+  const schema = createStandardPageLayout()
+
+  assert.equal(schema.sections.footer.roundSafeInset, false)
+})
+
+test('createStandardPageLayout uses TOKENS.spacing values', () => {
+  const schema = createStandardPageLayout()
+
+  // Body should reference header via 'after' property with gap
+  assert.equal(schema.sections.body.after, 'header')
+  assert.ok(schema.sections.body.gap)
+})
+
+test('createStandardPageLayout schema resolves correctly with layout-engine', () => {
+  const schema = createStandardPageLayout()
+  const layout = resolveLayout(schema, mockMetrics)
+
+  // All sections should resolve to valid coordinates
+  assert.ok(layout.sections.header)
+  assert.ok(layout.sections.body)
+  assert.ok(layout.sections.footer)
+
+  assert.equal(typeof layout.sections.header.x, 'number')
+  assert.equal(typeof layout.sections.header.y, 'number')
+  assert.equal(typeof layout.sections.header.w, 'number')
+  assert.equal(typeof layout.sections.header.h, 'number')
+})
+
+test('createStandardPageLayout without header resolves correctly', () => {
+  const schema = createStandardPageLayout({ hasHeader: false })
+  const layout = resolveLayout(schema, mockMetrics)
+
+  assert.equal(layout.sections.header, undefined)
+  assert.ok(layout.sections.body)
+  assert.ok(layout.sections.footer)
+})
+
+test('createStandardPageLayout custom headerHeight is applied', () => {
+  const schema = createStandardPageLayout({ headerHeight: '20%' })
+
+  assert.equal(schema.sections.header.height, '20%')
+})
+
+test('createStandardPageLayout custom footerHeight is applied', () => {
+  const schema = createStandardPageLayout({ footerHeight: '15%' })
+
+  assert.equal(schema.sections.footer.height, '15%')
+})
+
+// ============================================
+// Test 2: createPageWithFooterButton
+// ============================================
+test('createPageWithFooterButton returns schema with footer button', () => {
+  const schema = createPageWithFooterButton()
+
+  assert.ok(schema.sections.header)
+  assert.ok(schema.sections.body)
+  assert.ok(schema.sections.footer)
+  assert.ok(schema.elements.footerButton)
+})
+
+test('createPageWithFooterButton button is in footer section', () => {
+  const schema = createPageWithFooterButton()
+
+  assert.equal(schema.elements.footerButton.section, 'footer')
+})
+
+test('createPageWithFooterButton button is centered', () => {
+  const schema = createPageWithFooterButton()
+
+  assert.equal(schema.elements.footerButton.x, 'center')
+  assert.equal(schema.elements.footerButton.y, 'center')
+  assert.equal(schema.elements.footerButton.align, 'center')
+})
+
+test('createPageWithFooterButton uses default icon', () => {
+  const schema = createPageWithFooterButton()
+
+  assert.equal(schema.elements.footerButton._icon, 'home-icon.png')
+})
+
+test('createPageWithFooterButton accepts custom icon', () => {
+  const schema = createPageWithFooterButton({ icon: 'custom-icon.png' })
+
+  assert.equal(schema.elements.footerButton._icon, 'custom-icon.png')
+})
+
+test('createPageWithFooterButton stores onClick callback', () => {
+  const onClick = () => {}
+  const schema = createPageWithFooterButton({ onClick })
+
+  assert.equal(schema.elements.footerButton._onClick, onClick)
+})
+
+test('createPageWithFooterButton always has footer even if hasHeader is false', () => {
+  const schema = createPageWithFooterButton({ hasHeader: false })
+
+  assert.equal(schema.sections.header, undefined)
+  assert.ok(schema.sections.footer)
+})
+
+test('createPageWithFooterButton schema resolves correctly', () => {
+  const schema = createPageWithFooterButton()
+  const layout = resolveLayout(schema, mockMetrics)
+
+  assert.ok(layout.sections.footer)
+  assert.ok(layout.elements.footerButton)
+  assert.equal(typeof layout.elements.footerButton.x, 'number')
+  assert.equal(typeof layout.elements.footerButton.y, 'number')
+})
+
+// ============================================
+// Test 3: createTwoColumnLayout
+// ============================================
+test('createTwoColumnLayout returns elements with left and right columns', () => {
+  const schema = createTwoColumnLayout('body')
+
+  assert.ok(schema.elements)
+  assert.ok(schema.elements.leftColumn)
+  assert.ok(schema.elements.rightColumn)
+})
+
+test('createTwoColumnLayout columns have correct parent section', () => {
+  const schema = createTwoColumnLayout('content')
+
+  assert.equal(schema.elements.leftColumn.section, 'content')
+  assert.equal(schema.elements.rightColumn.section, 'content')
+})
+
+test('createTwoColumnLayout columns are 50% width', () => {
+  const schema = createTwoColumnLayout('body')
+
+  assert.equal(schema.elements.leftColumn.width, '50%')
+  assert.equal(schema.elements.rightColumn.width, '50%')
+})
+
+test('createTwoColumnLayout columns are 100% height', () => {
+  const schema = createTwoColumnLayout('body')
+
+  assert.equal(schema.elements.leftColumn.height, '100%')
+  assert.equal(schema.elements.rightColumn.height, '100%')
+})
+
+test('createTwoColumnLayout left column starts at x: 0', () => {
+  const schema = createTwoColumnLayout('body')
+
+  assert.equal(schema.elements.leftColumn.x, 0)
+})
+
+test('createTwoColumnLayout right column starts at x: 50%', () => {
+  const schema = createTwoColumnLayout('body')
+
+  assert.equal(schema.elements.rightColumn.x, '50%')
+})
+
+test('createTwoColumnLayout with empty parent section returns empty elements', () => {
+  const schema = createTwoColumnLayout('')
+
+  assert.deepEqual(schema.elements, {})
+})
+
+test('createTwoColumnLayout with null parent section returns empty elements', () => {
+  const schema = createTwoColumnLayout(null)
+
+  assert.deepEqual(schema.elements, {})
+})
+
+test('createTwoColumnLayout with undefined parent section returns empty elements', () => {
+  const schema = createTwoColumnLayout(undefined)
+
+  assert.deepEqual(schema.elements, {})
+})
+
+test('createTwoColumnLayout resolves correctly with parent section', () => {
+  const pageLayout = createStandardPageLayout()
+  const columnLayout = createTwoColumnLayout('body')
+  pageLayout.elements = { ...pageLayout.elements, ...columnLayout.elements }
+
+  const layout = resolveLayout(pageLayout, mockMetrics)
+
+  assert.ok(layout.elements.leftColumn)
+  assert.ok(layout.elements.rightColumn)
+
+  // Left column should be in left half
+  assert.ok(layout.elements.leftColumn.x < mockMetrics.width / 2)
+
+  // Right column should be in right half
+  assert.ok(layout.elements.rightColumn.x >= mockMetrics.width / 2)
+})
+
+// ============================================
+// Test 4: createGamePageLayout
+// ============================================
+test('createGamePageLayout returns complete schema', () => {
+  const schema = createGamePageLayout()
+
+  assert.ok(schema.sections.header)
+  assert.ok(schema.sections.body)
+  assert.ok(schema.sections.footer)
+  assert.ok(schema.elements.footerButton)
+  assert.ok(schema.elements.leftColumn)
+  assert.ok(schema.elements.rightColumn)
+})
+
+test('createGamePageLayout uses default footer icon', () => {
+  const schema = createGamePageLayout()
+
+  assert.equal(schema.elements.footerButton._icon, 'home-icon.png')
+})
+
+test('createGamePageLayout accepts custom footer icon', () => {
+  const schema = createGamePageLayout({ footerIcon: 'back-icon.png' })
+
+  assert.equal(schema.elements.footerButton._icon, 'back-icon.png')
+})
+
+test('createGamePageLayout stores onFooterClick callback', () => {
+  const onFooterClick = () => {}
+  const schema = createGamePageLayout({ onFooterClick })
+
+  assert.equal(schema.elements.footerButton._onClick, onFooterClick)
+})
+
+test('createGamePageLayout columns are in body section', () => {
+  const schema = createGamePageLayout()
+
+  assert.equal(schema.elements.leftColumn.section, 'body')
+  assert.equal(schema.elements.rightColumn.section, 'body')
+})
+
+test('createGamePageLayout schema resolves correctly', () => {
+  const schema = createGamePageLayout()
+  const layout = resolveLayout(schema, mockMetrics)
+
+  assert.ok(layout.sections.header)
+  assert.ok(layout.sections.body)
+  assert.ok(layout.sections.footer)
+  assert.ok(layout.elements.leftColumn)
+  assert.ok(layout.elements.rightColumn)
+  assert.ok(layout.elements.footerButton)
+})
+
+// ============================================
+// Test 5: mergeLayouts
+// ============================================
+test('mergeLayouts combines sections from multiple schemas', () => {
+  const schema1 = { sections: { header: { height: '10%' } }, elements: {} }
+  const schema2 = { sections: { footer: { height: '10%' } }, elements: {} }
+
+  const merged = mergeLayouts(schema1, schema2)
+
+  assert.ok(merged.sections.header)
+  assert.ok(merged.sections.footer)
+})
+
+test('mergeLayouts combines elements from multiple schemas', () => {
+  const schema1 = { sections: {}, elements: { title: { x: 0 } } }
+  const schema2 = { sections: {}, elements: { button: { x: 100 } } }
+
+  const merged = mergeLayouts(schema1, schema2)
+
+  assert.ok(merged.elements.title)
+  assert.ok(merged.elements.button)
+})
+
+test('mergeLayouts later schemas override earlier ones', () => {
+  const schema1 = { sections: { header: { height: '10%' } }, elements: {} }
+  const schema2 = { sections: { header: { height: '20%' } }, elements: {} }
+
+  const merged = mergeLayouts(schema1, schema2)
+
+  assert.equal(merged.sections.header.height, '20%')
+})
+
+test('mergeLayouts handles null schemas', () => {
+  const schema = { sections: { header: {} }, elements: {} }
+
+  const merged = mergeLayouts(null, schema, undefined)
+
+  assert.ok(merged.sections.header)
+})
+
+test('mergeLayouts handles empty input', () => {
+  const merged = mergeLayouts()
+
+  assert.deepEqual(merged.sections, {})
+  assert.deepEqual(merged.elements, {})
+})
+
+test('mergeLayouts with invalid schema types', () => {
+  const merged = mergeLayouts('invalid', 123, {
+    sections: { header: {} },
+    elements: {}
+  })
+
+  assert.ok(merged.sections.header)
+})
+
+test('mergeLayouts preserves sections without elements', () => {
+  const schema = { sections: { header: { height: '10%' } } }
+
+  const merged = mergeLayouts(schema)
+
+  assert.ok(merged.sections.header)
+  assert.deepEqual(merged.elements, {})
+})
+
+// ============================================
+// Test 6: Token Integration
+// ============================================
+test('createStandardPageLayout uses TOKENS.typography values', () => {
+  const schema = createStandardPageLayout()
+
+  // Default header height should be based on pageTitle token
+  assert.ok(schema.sections.header.height)
+  assert.ok(schema.sections.footer.height)
+})
+
+test('createStandardPageLayout uses TOKENS.spacing.pageTop', () => {
+  const schema = createStandardPageLayout()
+
+  // Header top should use pageTop token
+  const expectedTop = `${TOKENS.spacing.pageTop * 100}%`
+  assert.equal(schema.sections.header.top, expectedTop)
+})
+
+test('createStandardPageLayout uses TOKENS.spacing.footerBottom', () => {
+  const schema = createStandardPageLayout()
+
+  // Footer bottom should use footerBottom token
+  const expectedBottom = `${TOKENS.spacing.footerBottom * 100}%`
+  assert.equal(schema.sections.footer.bottom, expectedBottom)
+})
+
+test('createStandardPageLayout uses TOKENS.spacing.headerToContent for body gap', () => {
+  const schema = createStandardPageLayout()
+
+  const expectedGap = `${TOKENS.spacing.headerToContent * 100}%`
+  assert.equal(schema.sections.body.gap, expectedGap)
+})
+
+// ============================================
+// Test 7: Round Screen Handling
+// ============================================
+test('createStandardPageLayout body has roundSafeInset on round screens', () => {
+  const schema = createStandardPageLayout()
+  const layout = resolveLayout(schema, mockRoundMetrics)
+
+  // Body section should have side inset on round screen
+  assert.ok(layout.sections.body.x > 0)
+  assert.ok(layout.sections.body.w < mockRoundMetrics.width)
+})
+
+test('createStandardPageLayout header has roundSafeInset on round screens', () => {
+  const schema = createStandardPageLayout()
+  const layout = resolveLayout(schema, mockRoundMetrics)
+
+  // Header section should have side inset on round screen
+  assert.ok(layout.sections.header.x > 0)
+  assert.ok(layout.sections.header.w < mockRoundMetrics.width)
+})
+
+test('createStandardPageLayout footer does not have roundSafeInset', () => {
+  const schema = createStandardPageLayout()
+  const layout = resolveLayout(schema, mockRoundMetrics)
+
+  // Footer should use full width (roundSafeInset: false)
+  assert.equal(layout.sections.footer.x, 0)
+  assert.equal(layout.sections.footer.w, mockRoundMetrics.width)
+})
+
+// ============================================
+// Test 8: Complex Scenarios
+// ============================================
+test('merged layout with preset and custom sections resolves correctly', () => {
+  const baseLayout = createStandardPageLayout()
+  const customLayout = {
+    sections: {
+      customSection: { height: '10%', after: 'body' }
+    },
+    elements: {
+      customElement: {
+        section: 'customSection',
+        x: '10%',
+        y: '10%',
+        width: '80%',
+        height: '80%'
+      }
+    }
+  }
+
+  const merged = mergeLayouts(baseLayout, customLayout)
+  const layout = resolveLayout(merged, mockMetrics)
+
+  assert.ok(layout.sections.header)
+  assert.ok(layout.sections.body)
+  assert.ok(layout.sections.footer)
+  assert.ok(layout.sections.customSection)
+  assert.ok(layout.elements.customElement)
+})
+
+test('page with footer button resolves button position correctly', () => {
+  const schema = createPageWithFooterButton()
+  const layout = resolveLayout(schema, mockMetrics)
+
+  // Button should be centered in footer
+  const footerCenterX = layout.sections.footer.x + layout.sections.footer.w / 2
+  const buttonCenterX =
+    layout.elements.footerButton.x + layout.elements.footerButton.w / 2
+
+  // Allow some tolerance for rounding
+  assert.ok(Math.abs(footerCenterX - buttonCenterX) < 2)
+})
+
+test('two-column layout in body creates proper split', () => {
+  const pageLayout = createStandardPageLayout()
+  const columnLayout = createTwoColumnLayout('body')
+  pageLayout.elements = { ...pageLayout.elements, ...columnLayout.elements }
+
+  const layout = resolveLayout(pageLayout, mockMetrics)
+
+  // Left and right columns should not overlap
+  const leftRight = layout.elements.leftColumn.x + layout.elements.leftColumn.w
+  assert.ok(leftRight <= layout.elements.rightColumn.x + 1) // +1 for rounding tolerance
+
+  // Combined width should equal body width
+  const combinedWidth =
+    layout.elements.leftColumn.w + layout.elements.rightColumn.w
+  assert.equal(combinedWidth, layout.sections.body.w)
+})

--- a/utils/layout-presets.js
+++ b/utils/layout-presets.js
@@ -1,0 +1,277 @@
+/**
+ * @fileoverview Layout presets utility providing factory functions for common page structure schemas.
+ *
+ * This module provides reusable layout schemas that follow a strict 3-section structure
+ * (header, body, footer) with consistent spacing and round-safe inset handling.
+ * All schemas are compatible with the layout-engine.js resolveLayout function.
+ *
+ * @module utils/layout-presets
+ */
+
+import { TOKENS } from './design-tokens.js'
+
+/**
+ * Creates a standard page layout schema with header, body, and footer sections.
+ *
+ * The layout follows a 3-section vertical structure:
+ * - Header: positioned at page top with configurable height
+ * - Body: fills remaining space between header and footer
+ * - Footer: anchored at page bottom with configurable height
+ *
+ * @param {Object} [options={}] - Layout configuration options
+ * @param {boolean} [options.hasHeader=true] - Whether to include header section
+ * @param {boolean} [options.hasFooter=true] - Whether to include footer section
+ * @param {string|number} [options.headerHeight] - Header height (default: based on pageTitle typography)
+ * @param {string|number} [options.footerHeight] - Footer height (default: based on button typography)
+ * @returns {Object} Layout schema compatible with resolveLayout()
+ *
+ * @example
+ * // Default layout with all sections
+ * const schema = createStandardPageLayout()
+ * // Returns: { sections: { header: {...}, body: {...}, footer: {...} } }
+ *
+ * @example
+ * // Layout without header
+ * const schema = createStandardPageLayout({ hasHeader: false })
+ *
+ * @example
+ * // Custom header and footer heights
+ * const schema = createStandardPageLayout({
+ *   headerHeight: '15%',
+ *   footerHeight: '80px'
+ * })
+ */
+export function createStandardPageLayout(options = {}) {
+  const {
+    hasHeader = true,
+    hasFooter = true,
+    headerHeight = `${TOKENS.typography.pageTitle * 200}%`,
+    footerHeight = `${TOKENS.typography.button * 200}%`
+  } = options
+
+  const sections = {}
+
+  // Header section - at page top, round safe inset enabled
+  if (hasHeader) {
+    sections.header = {
+      top: `${TOKENS.spacing.pageTop * 100}%`,
+      height: headerHeight,
+      roundSafeInset: true
+    }
+  }
+
+  // Body section - fills remaining space, round safe inset enabled
+  sections.body = {
+    height: 'fill',
+    roundSafeInset: true
+  }
+
+  // Set body positioning based on header presence
+  if (hasHeader) {
+    sections.body.after = 'header'
+    sections.body.gap = `${TOKENS.spacing.headerToContent * 100}%`
+  } else {
+    sections.body.top = `${TOKENS.spacing.pageTop * 100}%`
+  }
+
+  // Footer section - anchored at bottom, round safe inset disabled
+  // (icon centering handles positioning on round screens)
+  if (hasFooter) {
+    sections.footer = {
+      bottom: `${TOKENS.spacing.footerBottom * 100}%`,
+      height: footerHeight,
+      roundSafeInset: false
+    }
+  }
+
+  return { sections, elements: {} }
+}
+
+/**
+ * Creates a standard page layout with a centered icon button in the footer.
+ *
+ * Extends createStandardPageLayout with an additional footer button element.
+ * The button is centered within the footer area for consistent positioning.
+ *
+ * @param {Object} [options={}] - Layout configuration options
+ * @param {string} [options.icon='home-icon.png'] - Icon filename for the button
+ * @param {Function} [options.onClick] - Click callback function (not included in schema)
+ * @param {boolean} [options.hasHeader=true] - Whether to include header section
+ * @param {string|number} [options.headerHeight] - Header height
+ * @param {string|number} [options.footerHeight] - Footer height
+ * @returns {Object} Layout schema with footer button element
+ *
+ * @example
+ * // Layout with home button in footer
+ * const schema = createPageWithFooterButton({
+ *   icon: 'home-icon.png',
+ *   onClick: () => navigateHome()
+ * })
+ *
+ * @example
+ * // Layout with custom icon
+ * const schema = createPageWithFooterButton({
+ *   icon: 'settings-icon.png',
+ *   hasHeader: false
+ * })
+ */
+export function createPageWithFooterButton(options = {}) {
+  const { icon = 'home-icon.png', onClick, ...layoutOptions } = options
+
+  // Get base layout from createStandardPageLayout
+  const baseLayout = createStandardPageLayout({
+    hasHeader: layoutOptions.hasHeader ?? true,
+    hasFooter: true, // Always include footer for button
+    headerHeight: layoutOptions.headerHeight,
+    footerHeight: layoutOptions.footerHeight
+  })
+
+  // Add footer button element
+  // The button is centered in the footer area
+  baseLayout.elements.footerButton = {
+    section: 'footer',
+    x: 'center',
+    y: 'center',
+    width: 48, // Standard icon size
+    height: 48,
+    align: 'center',
+    // Custom properties for button rendering (not used by layout-engine)
+    _icon: icon,
+    _onClick: onClick
+  }
+
+  return baseLayout
+}
+
+/**
+ * Creates a two-column layout schema nested under a parent section.
+ *
+ * Returns a schema with leftColumn and rightColumn sections, each taking
+ * 50% width and 100% height of the parent section. Useful for game page
+ * score area displays and other split-screen layouts.
+ *
+ * @param {string} parentSection - Name of the parent section to nest columns under
+ * @returns {Object} Schema fragment with leftColumn and rightColumn elements
+ *
+ * @example
+ * // Create two columns within the body section
+ * const columns = createTwoColumnLayout('body')
+ * // Returns: { elements: { leftColumn: {...}, rightColumn: {...} } }
+ *
+ * @example
+ * // Use with standard page layout
+ * const pageLayout = createStandardPageLayout()
+ * const columnLayout = createTwoColumnLayout('body')
+ * pageLayout.elements = { ...pageLayout.elements, ...columnLayout.elements }
+ */
+export function createTwoColumnLayout(parentSection) {
+  if (typeof parentSection !== 'string' || parentSection.length === 0) {
+    return { elements: {} }
+  }
+
+  return {
+    elements: {
+      leftColumn: {
+        section: parentSection,
+        x: 0,
+        y: 0,
+        width: '50%',
+        height: '100%',
+        align: 'left'
+      },
+      rightColumn: {
+        section: parentSection,
+        x: '50%',
+        y: 0,
+        width: '50%',
+        height: '100%',
+        align: 'left'
+      }
+    }
+  }
+}
+
+/**
+ * Creates a complete game page layout schema with header, two-column score area, and footer button.
+ *
+ * Combines createStandardPageLayout, createTwoColumnLayout, and createPageWithFooterButton
+ * into a single convenient factory for the game scoring screen.
+ *
+ * @param {Object} [options={}] - Layout configuration options
+ * @param {string} [options.footerIcon='home-icon.png'] - Icon for footer button
+ * @param {Function} [options.onFooterClick] - Click callback for footer button
+ * @returns {Object} Complete game page layout schema
+ *
+ * @example
+ * const gameLayout = createGamePageLayout({
+ *   footerIcon: 'home-icon.png',
+ *   onFooterClick: () => navigateHome()
+ * })
+ */
+export function createGamePageLayout(options = {}) {
+  const { footerIcon = 'home-icon.png', onFooterClick } = options
+
+  // Start with standard layout
+  const layout = createStandardPageLayout({
+    hasHeader: true,
+    hasFooter: true
+  })
+
+  // Add two-column layout to body
+  const columnLayout = createTwoColumnLayout('body')
+
+  // Add footer button
+  layout.elements.footerButton = {
+    section: 'footer',
+    x: 'center',
+    y: 'center',
+    width: 48,
+    height: 48,
+    align: 'center',
+    _icon: footerIcon,
+    _onClick: onFooterClick
+  }
+
+  // Merge column elements
+  layout.elements = {
+    ...layout.elements,
+    ...columnLayout.elements
+  }
+
+  return layout
+}
+
+/**
+ * Merges multiple layout schemas into a single schema.
+ *
+ * Useful for combining preset layouts with custom sections and elements.
+ * Later schemas override earlier ones for conflicting keys.
+ *
+ * @param {...Object} schemas - Layout schemas to merge
+ * @returns {Object} Merged layout schema
+ *
+ * @example
+ * const baseLayout = createStandardPageLayout()
+ * const customLayout = {
+ *   sections: { customSection: { height: '10%', after: 'body' } },
+ *   elements: { customElement: { section: 'customSection', ... } }
+ * }
+ * const merged = mergeLayouts(baseLayout, customLayout)
+ */
+export function mergeLayouts(...schemas) {
+  const result = { sections: {}, elements: {} }
+
+  for (const schema of schemas) {
+    if (!schema || typeof schema !== 'object') continue
+
+    if (schema.sections && typeof schema.sections === 'object') {
+      result.sections = { ...result.sections, ...schema.sections }
+    }
+
+    if (schema.elements && typeof schema.elements === 'object') {
+      result.elements = { ...result.elements, ...schema.elements }
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary

Implements `utils/layout-presets.js` containing factory functions that return layout schemas for common page patterns following a strict 3-section structure (header, body, footer) with consistent spacing and round-safe inset handling.

## Changes

- **createStandardPageLayout(options)**: Returns layout schema with header, body, and footer sections
  - Configurable `hasHeader` and `hasFooter` options
  - Custom `headerHeight` and `footerHeight` support
  - Uses `TOKENS.spacing` values for consistent positioning
  - `roundSafeInset: true` for body/header, `false` for footer

- **createPageWithFooterButton(options)**: Standard layout with centered footer button
  - Extends `createStandardPageLayout` with footer button element
  - Customizable icon and click callback

- **createTwoColumnLayout(parentSection)**: Two-column schema for split-screen layouts
  - Each column 50% width, 100% height
  - Safe handling of invalid parent section

- **createGamePageLayout(options)**: Complete game page layout combining all presets
  - Header, two-column body, footer with button

- **mergeLayouts(...schemas)**: Utility to combine multiple layout schemas

## Testing

- Comprehensive test suite with 54 tests covering:
  - Schema structure validation
  - Section configuration options
  - Token integration
  - Round screen handling
  - Layout resolution with layout-engine
  - Complex scenarios

## Related

- Closes #43
- Depends on #40 (design-tokens.js) and #42 (layout-engine.js)